### PR TITLE
Update coverage.r

### DIFF
--- a/lib/coverage.r
+++ b/lib/coverage.r
@@ -508,7 +508,7 @@ libSizeBam <- function(bam.list) {
 
     # Count only reads that are mapped, primary, passed quality control and 
     # un-duplicated.
-    sbp <- ScanBamParam(flag=scanBamFlag(isUnmappedQuery=F, isNotPrimaryRead=F, 
+    sbp <- ScanBamParam(flag=scanBamFlag(isUnmappedQuery=F, isSecondaryAlignment=F, 
                         isNotPassingQualityControls=F, isDuplicate=F))
     v.lib.size <- vector('integer', length=length(bam.list))
     for(i in 1:length(bam.list)) {


### PR DESCRIPTION
change:
'isNotPrimaryRead' is deprecated.
Use 'isSecondaryAlignment' instead.